### PR TITLE
Mutex API migration

### DIFF
--- a/application.fam
+++ b/application.fam
@@ -1,9 +1,8 @@
 App(
-    appid="Sentry_Safe",
-    name="Sentry Safe",
+    appid="GPIO_Sentry_Safe",
+    name="[GPIO] Sentry Safe",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="sentry_safe_app",
-    cdefines=["APP_SENTRY_SAFE"],
     requires=["gui"],
     stack_size=1 * 1024,
     order=40,

--- a/sentry_safe.c
+++ b/sentry_safe.c
@@ -2,11 +2,13 @@
 #include <gui/gui.h>
 #include <input/input.h>
 #include <stdlib.h>
+#include <dolphin/dolphin.h>
 
 #include <furi_hal.h>
 
 typedef struct {
     uint8_t status;
+    FuriMutex* mutex;
 } SentryState;
 
 typedef enum {
@@ -22,10 +24,9 @@ typedef struct {
 const char* status_texts[3] = {"[Press OK to open safe]", "Sending...", "Done !"};
 
 static void sentry_safe_render_callback(Canvas* const canvas, void* ctx) {
-    const SentryState* sentry_state = acquire_mutex((ValueMutex*)ctx, 25);
-    if(sentry_state == NULL) {
-        return;
-    }
+    furi_assert(ctx);
+    const SentryState* sentry_state = ctx;
+    furi_mutex_acquire(sentry_state->mutex, FuriWaitForever);
 
     // Before the function is called, the state is set with the canvas_reset(canvas)
 
@@ -41,7 +42,7 @@ static void sentry_safe_render_callback(Canvas* const canvas, void* ctx) {
     canvas_draw_str_aligned(
         canvas, 64, 50, AlignCenter, AlignBottom, status_texts[sentry_state->status]);
 
-    release_mutex((ValueMutex*)ctx, sentry_state);
+    furi_mutex_release(sentry_state->mutex);
 }
 
 static void sentry_safe_input_callback(InputEvent* input_event, FuriMessageQueue* event_queue) {
@@ -84,13 +85,14 @@ int32_t sentry_safe_app(void* p) {
     UNUSED(p);
 
     FuriMessageQueue* event_queue = furi_message_queue_alloc(8, sizeof(Event));
+    DOLPHIN_DEED(DolphinDeedPluginStart);
 
     SentryState* sentry_state = malloc(sizeof(SentryState));
 
     sentry_state->status = 0;
 
-    ValueMutex state_mutex;
-    if(!init_mutex(&state_mutex, sentry_state, sizeof(SentryState))) {
+    sentry_state->mutex = furi_mutex_alloc(FuriMutexTypeNormal);
+    if(!sentry_state->mutex) {
         FURI_LOG_E("SentrySafe", "cannot create mutex\r\n");
         furi_message_queue_free(event_queue);
         free(sentry_state);
@@ -98,7 +100,7 @@ int32_t sentry_safe_app(void* p) {
     }
 
     ViewPort* view_port = view_port_alloc();
-    view_port_draw_callback_set(view_port, sentry_safe_render_callback, &state_mutex);
+    view_port_draw_callback_set(view_port, sentry_safe_render_callback, sentry_state);
     view_port_input_callback_set(view_port, sentry_safe_input_callback, event_queue);
 
     // Open GUI and register view_port
@@ -109,7 +111,7 @@ int32_t sentry_safe_app(void* p) {
     for(bool processing = true; processing;) {
         FuriStatus event_status = furi_message_queue_get(event_queue, &event, 100);
 
-        SentryState* sentry_state = (SentryState*)acquire_mutex_block(&state_mutex);
+        furi_mutex_acquire(sentry_state->mutex, FuriWaitForever);
 
         if(event_status == FuriStatusOk) {
             // press events
@@ -151,7 +153,7 @@ int32_t sentry_safe_app(void* p) {
         }
 
         view_port_update(view_port);
-        release_mutex(&state_mutex, sentry_state);
+        furi_mutex_release(sentry_state->mutex);
     }
 
     // Reset GPIO pins to default state
@@ -162,7 +164,7 @@ int32_t sentry_safe_app(void* p) {
     furi_record_close(RECORD_GUI);
     view_port_free(view_port);
     furi_message_queue_free(event_queue);
-    delete_mutex(&state_mutex);
+    furi_mutex_free(sentry_state->mutex);
     free(sentry_state);
 
     return 0;


### PR DESCRIPTION
## Description

Trying to compile the project with a recent Firmware I noticed that the application does not work.

I later discovered this is due to the recent changes to the Mutex API.

Searching online I found a version of [flipperzero-sentry-safe-plugin](https://github.com/RogueMaster/flipperzero-firmware-wPlugins/tree/420/applications/external/sentry_safe) already migrated within the RogueMaster Firmware applications.

I think it might be useful to use this migrated version.

It seems to work, although I have not had a chance to test my fork code on the FlipperZero.

## Issues
- #6 
- #4 

